### PR TITLE
Update requires to v8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         }
     },
     "require": {
-        "php": "^7.3",
+        "php": "^7.3|^8.0|^8.1",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^6.5|^7.0"
     },


### PR DESCRIPTION
Update composer.json with new requires statement, so library can be used with PHP v8.1. I don't yet know if any actual code updates will be required.